### PR TITLE
Adds an example for dim showcasing how it can be used inside custom-made gems

### DIFF
--- a/dim/examples/scripting/dim_to_rst/.gitignore
+++ b/dim/examples/scripting/dim_to_rst/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status
+Gemfile.lock

--- a/dim/examples/scripting/dim_to_rst/.rspec
+++ b/dim/examples/scripting/dim_to_rst/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/dim/examples/scripting/dim_to_rst/CHANGELOG.md
+++ b/dim/examples/scripting/dim_to_rst/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/dim/examples/scripting/dim_to_rst/CHANGELOG.md
+++ b/dim/examples/scripting/dim_to_rst/CHANGELOG.md
@@ -6,3 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0] - 2024-11-27
+
+### Changed
+- ! Adapted the code for `dim-toolkit` `>= 2.1.1`
+
+## [1.0.1] - 2023-10-06
+
+### Fixed
+- Fixed a `NoMethodError` that was introduced with `activesupport 7.1.0`.
+
+## [1.0.0] - 2023-05-15
+
+### Changed
+- ! Update `activesupport` from `~> 6` to `~> 7`
+
+## [0.1.0] - 2022-11-22
+
+### Added
+- Executable file and necessary templates to read the DIM requirements and
+  produce basic RST output. 

--- a/dim/examples/scripting/dim_to_rst/Gemfile
+++ b/dim/examples/scripting/dim_to_rst/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in dim_to_rst.gemspec
+gemspec
+
+gem "rake", "~> 13"
+gem "rspec", "~> 3"

--- a/dim/examples/scripting/dim_to_rst/README.md
+++ b/dim/examples/scripting/dim_to_rst/README.md
@@ -1,0 +1,32 @@
+# Dim to RST
+
+This example illustrates how to use [dim](https://github.com/esrlabs/dox/tree/master/dim)
+inside a gem.
+
+This example shows how to create a custom requirements exporter.
+
+## Installation
+
+Install the gem and add to the application's Gemfile by executing:
+
+    $ bundle add dim_to_rst
+
+If bundler is not being used to manage dependencies, install the gem by executing:
+
+    $ gem install dim_to_rst
+
+## Usage
+
+    $ dim_to_rst <path/to/config.yaml> <export/destination>
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests.
+
+To install this gem onto your local machine, run `bundle exec rake install`.
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+[https://github.com/esrlabs/dox/tree/master/dim/examples/scripting/dim_to_rst].

--- a/dim/examples/scripting/dim_to_rst/Rakefile
+++ b/dim/examples/scripting/dim_to_rst/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new
+
+task default: %i[spec rubocop]

--- a/dim/examples/scripting/dim_to_rst/bin/console
+++ b/dim/examples/scripting/dim_to_rst/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "dim_to_rst"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)

--- a/dim/examples/scripting/dim_to_rst/bin/setup
+++ b/dim/examples/scripting/dim_to_rst/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/dim/examples/scripting/dim_to_rst/dim_to_rst.gemspec
+++ b/dim/examples/scripting/dim_to_rst/dim_to_rst.gemspec
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "lib/dim_to_rst/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "dim_to_rst"
+  spec.version = DimToRst::VERSION
+  spec.authors = ["Accenture"]
+
+  spec.summary = "An example of a custom exporter gem for dim."
+  spec.description = "Exports requirements written in dim to plain RST source."
+  spec.homepage = "https://github.com/esrlabs/dox/tree/master/dim/examples/scripting/dim_to_rst"
+  spec.required_ruby_version = ">= 2.7"
+
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://github.com/esrlabs/dox/tree/master/dim/examples/scripting/dim_to_rst/CHANGELOG.md"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[exe/ lib/ CHANGELOG.md README.md])
+    end
+  end
+
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "activesupport", "~> 7"
+  spec.add_dependency "dim-toolkit", '>= 2.1.1'
+end

--- a/dim/examples/scripting/dim_to_rst/exe/dim_to_rst
+++ b/dim/examples/scripting/dim_to_rst/exe/dim_to_rst
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "active_support"
+require "active_support/core_ext/string"
+require "dim/loader"
+require "erb"
+require "fileutils"
+
+# rubocop:disable Style/GlobalVars
+# (required by DIM)
+$subcommands = {}
+# rubocop:enable Style/GlobalVars
+
+def asil_level(requirement)
+  requirement.asil == "not_set" ? nil : "#{requirement.asil} |"
+end
+
+def req_text(requirement)
+  buffer = StringIO.new
+  text_lines = requirement.text.lines.map(&:chomp)
+  buffer << text_lines.shift
+
+  if text_lines.any?
+    text_lines.each do |line|
+      buffer << "\n#{line.indent(7)}"
+    end
+  end
+
+  buffer.string
+end
+
+def req_refs(references)
+  return "none" unless references&.any?
+
+  references.map { |ref| ":ref:`dim-req-#{ref}`" }.join(', ')
+end
+
+input_file = ARGV.shift
+output_dir = ARGV.shift
+
+@loader = Dim::Loader.new.tap do |loader|
+  loader.load input_filenames: [input_file]
+end
+
+categories = {}
+
+@loader.requirements.each_value do |requirement|
+  category_name = requirement.category
+
+  category_data = categories[category_name] ||= {}
+  category_data[:name] = category_name
+  category_data[:id] = category_name.parameterize.downcase
+  category_requirements = category_data[:requirements] ||= []
+  category_requirements << requirement
+
+  module_name = requirement.moduleName
+  category_modules = category_data[:modules] ||= {}
+  module_data = category_modules[module_name] ||= {}
+  module_data[:name] = module_name
+  module_data[:id] = module_name.parameterize.downcase
+  module_requirements = module_data[:requirements] ||= []
+  module_requirements << requirement
+end
+
+templates_path = Pathname.new(__dir__) / ".." / "lib" / "dim_to_rst" / "templates"
+
+index_template = File.read(templates_path / "index.rst.erb")
+index_erb = ERB.new(index_template)
+index_dest = File.join(output_dir, "index.rst")
+
+File.write(index_dest, index_erb.result_with_hash(
+  categories: categories
+))
+
+module_template = File.read(templates_path / "module.rst.erb")
+module_erb = ERB.new(module_template)
+
+categories.each do |category_name, category_data|
+  category_dir = File.join(output_dir, category_data[:id])
+
+  FileUtils.rm_rf(category_dir)
+  FileUtils.mkdir(category_dir)
+
+  category_data[:modules].each do |module_name, module_data|
+    module_dest = File.join(category_dir, "#{module_data[:id]}.rst")
+    File.write(module_dest, module_erb.result_with_hash(
+                              module_name: module_name, module_data: module_data
+                            ))
+  end
+end

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst.rb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "dim_to_rst/version"
+
+module DimToRst; end

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/index.rst.erb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/index.rst.erb
@@ -1,0 +1,16 @@
+Requirements
+============
+
+<% categories.each do |category_name, category_data| %>
+<% label = category_name.capitalize %>
+
+<%= label %>
+<%= '-' * label.length %>
+
+.. toctree::
+  :maxdepth: 1
+  :glob:
+
+  <%= category_data[:id] %>/*
+
+<% end %>

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/module.rst.erb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/module.rst.erb
@@ -1,0 +1,20 @@
+<%= module_name %>
+<%= '=' * module_name.length %>
+
+<% module_data[:requirements].each do |requirement|
+  requirement_id = requirement.id %>
+
+.. _`dim-req-<%= requirement_id %>`:
+
+<%= requirement_id %>
+<%= "-" * requirement_id.length %>
+
+.. list-table::
+
+   * - **<%= requirement_id %>** | <%= requirement.accepted %> | <%= asil_level(requirement) %> <%= requirement.origin %>
+   * - **Tags:** <%= requirement.tags %>
+   * - **Test Setups:** <%= requirement.test_setups %>
+   * - <%= req_text(requirement) %>
+   * - **References:** <%= req_refs(requirement.refs) %>
+   * - **Back References:** <%= req_refs(requirement.backwardRefs) %>
+<% end %>

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DimToRst
+  VERSION = "0.0.0"
+end

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DimToRst
-  VERSION = "0.0.0"
+  VERSION = "2.0.0"
 end

--- a/dim/examples/scripting/dim_to_rst/spec/dim_to_rst_spec.rb
+++ b/dim/examples/scripting/dim_to_rst/spec/dim_to_rst_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe DimToRst do
+  it "has a version number" do
+    expect(DimToRst::VERSION).not_to be nil
+  end
+end

--- a/dim/examples/scripting/dim_to_rst/spec/spec_helper.rb
+++ b/dim/examples/scripting/dim_to_rst/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "dim_to_rst"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Adds a new example for dim in which showcasing a way to use it inside a gem with its own CLI.
The `dim_to_rst` gem generates plain / pure RST source out of the given dim configuration and
requirements files:

* This exporter allows requirements to be exported to RST without the need to use any specific
  or custom template and without the need to have custom directives the produced output is
  plain RST.

* The gem doesn't perform any type of conversion on the requirement's text, which allow them to
  directly use RST syntax to include warnings, code blocks, tables, images, etc.