### PR TITLE
Fix the rendering of array type-fields as RST

### DIFF
--- a/dim/examples/scripting/dim_to_rst/CHANGELOG.md
+++ b/dim/examples/scripting/dim_to_rst/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2025-02-10
+
+### Fixed
+- The rendering of array-type fields, specifically **Tags** and **Test Setups**
+
 ## [2.0.0] - 2024-11-27
 
 ### Changed

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/module.rst.erb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/templates/module.rst.erb
@@ -12,8 +12,8 @@
 .. list-table::
 
    * - **<%= requirement_id %>** | <%= requirement.accepted %> | <%= asil_level(requirement) %> <%= requirement.origin %>
-   * - **Tags:** <%= requirement.tags %>
-   * - **Test Setups:** <%= requirement.test_setups %>
+   * - **Tags:** <%= requirement.tags&.join(', ') %>
+   * - **Test Setups:** <%= requirement.test_setups&.join(', ') %>
    * - <%= req_text(requirement) %>
    * - **References:** <%= req_refs(requirement.refs) %>
    * - **Back References:** <%= req_refs(requirement.backwardRefs) %>

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DimToRst
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Fixes the way in which the `dim_to_rst` example renders the **"Tags"** and **"Test Setups"** fields in the generated RST documents. They were being rendered directly as arrays, which didn't look so good.

### Before:

![Screenshot 2025-02-07 at 11 22 56](https://github.com/user-attachments/assets/86718ed4-5cb7-43ec-ab98-5eeaea1f9b6b)

### After:

![Screenshot 2025-02-07 at 11 29 14](https://github.com/user-attachments/assets/afe9906e-f252-4348-bfe9-a4fe5b419f1c)