### PR TITLE
Add StringIO explicitly to fix error on Ruby3.4

### DIFF
--- a/dim/lib/dim/dimmain.rb
+++ b/dim/lib/dim/dimmain.rb
@@ -1,6 +1,7 @@
 $stdout.sync = true
 
 require 'yaml'
+require 'stringio'
 
 require_relative 'globals'
 require_relative 'exit_helper'


### PR DESCRIPTION
Dim formatter failing on some systems with Ruby3.4 while loading StringIO class. This commits requires StringIO explicitly while loading the Dim for execution.

Fixes: #41