### PR TITLE
Make dim_to_rst compatible with Ruby 3.4.2+

### DIFF
--- a/dim/examples/scripting/dim_to_rst/CHANGELOG.md
+++ b/dim/examples/scripting/dim_to_rst/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-05-21
+
+### Fixed
+- Fixed a `NameError` for `StringIO` in Ruby 3.4.2+
+
 ## [2.0.1] - 2025-02-10
 
 ### Fixed

--- a/dim/examples/scripting/dim_to_rst/exe/dim_to_rst
+++ b/dim/examples/scripting/dim_to_rst/exe/dim_to_rst
@@ -6,6 +6,7 @@ require 'active_support/core_ext/string'
 require 'dim/loader'
 require 'erb'
 require 'fileutils'
+require 'stringio'
 
 # rubocop:disable Style/GlobalVars
 # (required by DIM)

--- a/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
+++ b/dim/examples/scripting/dim_to_rst/lib/dim_to_rst/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DimToRst
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
When executed with Ruby 3.4.2 a `NameError` for `StringIO` was being raised.

To fix the issue a `require` statement for `stringio` is being added to the `exe/dim_to_rst` file.